### PR TITLE
add link for MIT page in Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,15 @@
 -[x] Fix "myArticles" on ""username"Articles" on users page
 -[x] Add a button "SignIn && SignUp" on entry page instead link
 -[x] Add green color to "read more" link on main page
-
+-[] Add 3 types of buttons for header above the markdown field
+-[x] Add example for "enter your tags" field
+-[] Add a logout button after the user name
+-[x] Add link to MIT license text in footer
+-[] Add hover title text on the like buttons. EX- "Like/Unlike"
+-[] Add seconds/minutes/hours ago]
+-[] If tags coming from API, add support for display them under post text
+-[] Add article content text on the global feed. Supporting only 100words, if more add a threedots
+-[] Fix the published text in the entry fields
 
 [![RealWorld Frontend](https://img.shields.io/badge/realworld-frontend-%23783578.svg)](http://realworld.io)
 [![JavaScript Style Guide](https://img.shields.io/badge/code_style-standard-brightgreen.svg)](https://standardjs.com)

--- a/src/components/TheFooter.vue
+++ b/src/components/TheFooter.vue
@@ -8,7 +8,10 @@
         An interactive learning project from
         <a rel="noopener noreferrer" target="blank" href="https://thinkster.io"
           >Thinkster</a
-        >. Code &amp; design licensed under MIT.
+        >. Code &amp; design licensed under
+        <a target="_blank" href="https://en.wikipedia.org/wiki/MIT_License"
+          >MIT</a
+        >.
       </span>
     </div>
   </footer>


### PR DESCRIPTION
### Added
-Active link for MIT license page at the WIKI